### PR TITLE
Create config file for HoundCI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,5 @@
+erblint:
+  enabled: true
+
+stylelint:
+  enabled: true


### PR DESCRIPTION
I'm not really sure how HoundCI works, but apparently its set up already. It requires a config file to set which linters to use besides the default. I've added two linters that should hopefully help with HTML, CSS and JS.

- [Documentation for config file](http://help.houndci.com/configuration/hound)
- [Supported linters](http://help.houndci.com/configuration/supported-linters)