### PR TITLE
Use SimpleMDE as markdown editor

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+import org.jsoup.nodes.Document.OutputSettings;
 
 /** Handles fetching and saving {@link Message} instances. */
 @WebServlet("/messages")
@@ -76,7 +77,8 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    // Allow new line characters
+    String text = Jsoup.clean(request.getParameter("text"), "", Whitelist.none(),new OutputSettings().prettyPrint(false));
 
     Message message = new Message(user, text);
     datastore.storeMessage(message);

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -45,3 +45,8 @@
 .hidden {
   display: none;
 }
+
+/* Change the height of the SimpleMDE */
+.CodeMirror, .CodeMirror-scroll {
+	min-height: 200px;
+}

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -47,6 +47,7 @@
 }
 
 /* Change the height of the SimpleMDE */
-.CodeMirror, .CodeMirror-scroll {
-	min-height: 200px;
+.CodeMirror,
+.CodeMirror-scroll {
+  min-height: 200px;
 }

--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -2,8 +2,10 @@
 <html>
 <head>
   <title>Message Feed</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/user-page.css">
+  <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
   <script src="/js/build-message-div.js"></script>
   <script src="/js/public-feed-loader.js"></script>
 </head>

--- a/src/main/webapp/js/build-message-div.js
+++ b/src/main/webapp/js/build-message-div.js
@@ -19,7 +19,7 @@ function buildMessageDiv(message){
 
   const bodyDiv = document.createElement('div');
   bodyDiv.classList.add('message-body');
-  bodyDiv.appendChild(document.createTextNode(message.text));
+  bodyDiv.innerHTML = SimpleMDE.prototype.markdown(message.text.replace('&gt;', '>')); // Allow quotes
 
   const messageDiv = document.createElement('div');
   messageDiv.classList.add("message-div");

--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -86,10 +86,24 @@ function fetchMessages() {
       });
 }
 
+function loadMarkdownEditor() {
+  let simplemde = new SimpleMDE({
+    autoDownloadFontAwesome: true,
+  	autosave: {
+  		enabled: true,
+  		uniqueId: "message "
+  	},
+  	element: document.getElementById("message-input"),
+  	forceSync: true,
+  	status: false
+  });
+}
+
 /** Fetches data and populates the UI of the page. */
 function buildUI() {
   setPageTitle();
   showMessageFormIfViewingSelf();
   fetchMessages();
   fetchAboutMe();
+  loadMarkdownEditor();
 }

--- a/src/main/webapp/user-page.html
+++ b/src/main/webapp/user-page.html
@@ -19,8 +19,10 @@ limitations under the License.
   <head>
     <title>User Page</title>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
     <link rel="stylesheet" href="/css/main.css">
     <link rel="stylesheet" href="/css/user-page.css">
+    <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
     <script src="/js/build-message-div.js"></script>
     <script src="/js/user-page-loader.js"></script>
   </head>


### PR DESCRIPTION
Following the unguided project for styled text 1 and 2, this is an implementation of a markdown editor using [SimpleMDE](https://github.com/sparksuite/simplemde-markdown-editor).

User input is stored as markdown (after html sanitization) and parsed to html server side. 