### PR TITLE
Resize message images to fit within the containing div

### DIFF
--- a/src/main/webapp/js/build-message-div.js
+++ b/src/main/webapp/js/build-message-div.js
@@ -25,7 +25,9 @@ function buildMessageDiv(message){
   }
   const bodyDiv = document.createElement('div');
   bodyDiv.classList.add('message-body');
-  bodyDiv.innerHTML = SimpleMDE.prototype.markdown(message.text.replace('&gt;', '>')); // Allow quotes
+  var renderedHtml = SimpleMDE.prototype.markdown(message.text.replace('&gt;', '>')); // Allow quotes
+  renderedHtml = renderedHtml.replace(/<img /g, '<img class="w-100 p-1" ');
+  bodyDiv.innerHTML = renderedHtml;
 
   const messageDiv = document.createElement('div');
   messageDiv.classList.add("message-div");
@@ -66,7 +68,9 @@ function buildMessageInTimeline(message, flip){
 
   const bodyDiv = document.createElement('div');
   bodyDiv.classList.add('timeline-body');
-  bodyDiv.innerHTML = SimpleMDE.prototype.markdown(message.text.replace('&gt;', '>')); // Allow quotes
+  var renderedHtml = SimpleMDE.prototype.markdown(message.text.replace('&gt;', '>')); // Allow quotes
+  renderedHtml = renderedHtml.replace(/<img /g, '<img class="w-100 p-1" ');
+  bodyDiv.innerHTML = renderedHtml;
 
   const messageDiv = document.createElement('div');
   messageDiv.classList.add("timeline-panel");


### PR DESCRIPTION
Added width and padding class to message img.

The alternative was to edit the css in a file common to both feed and user page (like `timeline.css`), but because the html in a message is parsed by SimpleMDE, there is no easy way to identify the post images. 